### PR TITLE
Remove redundant display rule for item image

### DIFF
--- a/style.css
+++ b/style.css
@@ -38,7 +38,6 @@ button:hover {
     height: auto;
     display: none;
     margin: 1rem auto;
-    display: block;
 }
 #lang-switch {
     position: fixed;


### PR DESCRIPTION
## Summary
- Ensure #item-image is hidden by default by removing extraneous `display: block` rule.
- Confirm `loadItem` continues to reveal the image using `img.style.display = 'block'`.

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6895181eb09c8320a6a434c43b9a377d